### PR TITLE
CI: Add tests workflow, for PRs and default branch pushes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+on:
+  pull_request:
+  push:
+    branches: [ 'master' ]
+
+jobs:
+  Test:
+
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        node-version: [ 20.x, '${{ vars.NODE_VERSION }}' ]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Checkout the latest code
+      uses: actions/checkout@v6
+
+    - name: Setup node
+      uses: actions/setup-node@v6
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - run: npm ci
+    - run: npm test


### PR DESCRIPTION
Follow-up to #2.

(Marking as draft -- needs `package-lock.json`, as anticipated to land as part of that PR, #2).